### PR TITLE
Add udp support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ releases/
 *.bin
 logs/
 preferences.yaml
+.idea

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ deej is an **open-source hardware volume mixer** for Windows and Linux PCs. It l
 
 > **_New:_** [work-in-progress deej FAQ](./docs/faq/faq.md)!
 
-deej consists of a [lightweight desktop client](#features) written in Go, and an Arduino-based hardware setup that's simple and cheap to build. [**Check out some versions built by members of our community!**](./community.md)
+deej consists of a [lightweight desktop client](#features) written in Go, and an Arduino or ESP-based hardware setup that's simple and cheap to build. [**Check out some versions built by members of our community!**](./community.md)
 
 **[Download the latest release](https://github.com/omriharel/deej/releases/latest) | [Video demonstration](https://youtu.be/VoByJ4USMr8) | [Build video by Tech Always](https://youtu.be/x2yXbFiiAeI)**
 
@@ -59,8 +59,11 @@ deej is written in Go and [distributed](https://github.com/omriharel/deej/releas
 
 ### Hardware
 
+### Arduino boards
+
 - The sliders are connected to 5 (or as many as you like) analog pins on an Arduino Nano/Uno board. They're powered from the board's 5V output (see schematic)
 - The board connects via a USB cable to the PC
+- For more advanced users, if you have a Wi-Fi enabled board like an ESP8266 or an ESP32 you can also control deej through a network connection
 
 #### Schematic
 
@@ -101,6 +104,13 @@ baud_rate: 9600
 # adjust the amount of signal noise reduction depending on your hardware quality
 # supported values are "low" (excellent hardware), "default" (regular hardware) or "high" (bad, noisy hardware)
 noise_reduction: default
+
+# set this to "serial" to use deej with an arduino board connected via a serial port
+# set this to "udp" to listen for slider movements via a UDP network connection
+controller_type: serial
+
+# settings for the UDP connection
+udp_port: 16990
 ```
 
 - `master` is a special option to control the master volume of the system _(uses the default playback device)_

--- a/config.yaml
+++ b/config.yaml
@@ -25,3 +25,10 @@ baud_rate: 9600
 # adjust the amount of signal noise reduction depending on your hardware quality
 # supported values are "low" (excellent hardware), "default" (regular hardware) or "high" (bad, noisy hardware)
 noise_reduction: default
+
+# set this to "serial" to use deej with an arduino board connected via a serial port
+# set this to "udp" to listen for slider movements via a UDP network connection
+controller_type: serial
+
+# settings for the UDP connection
+udp_port: 16990

--- a/pkg/deej/deej.go
+++ b/pkg/deej/deej.go
@@ -20,11 +20,11 @@ const (
 
 // Deej is the main entity managing access to all sub-components
 type Deej struct {
-	logger   *zap.SugaredLogger
-	notifier Notifier
-	config   *CanonicalConfig
-	serial   *SerialIO
-	sessions *sessionMap
+	logger           *zap.SugaredLogger
+	notifier         Notifier
+	config           *CanonicalConfig
+	sliderController SliderController
+	sessions         *sessionMap
 
 	stopChannel chan bool
 	version     string
@@ -55,14 +55,6 @@ func NewDeej(logger *zap.SugaredLogger, verbose bool) (*Deej, error) {
 		verbose:     verbose,
 	}
 
-	serial, err := NewSerialIO(d, logger)
-	if err != nil {
-		logger.Errorw("Failed to create SerialIO", "error", err)
-		return nil, fmt.Errorf("create new SerialIO: %w", err)
-	}
-
-	d.serial = serial
-
 	sessionFinder, err := newSessionFinder(logger)
 	if err != nil {
 		logger.Errorw("Failed to create SessionFinder", "error", err)
@@ -90,6 +82,27 @@ func (d *Deej) Initialize() error {
 	if err := d.config.Load(); err != nil {
 		d.logger.Errorw("Failed to load config during initialization", "error", err)
 		return fmt.Errorf("load config during init: %w", err)
+	}
+
+	if d.config.ControllerType == "serial" {
+		serial, err := NewSerialIO(d, d.logger)
+		if err != nil {
+			d.logger.Errorw("Failed to create SerialIO", "error", err)
+			return fmt.Errorf("create new SerialIO: %w", err)
+		}
+
+		d.sliderController = serial
+
+		d.logger.Info("Created serial SliderController")
+	} else if d.config.ControllerType == "udp" {
+		udp, err := NewUdpIO(d, d.logger)
+		if err != nil {
+			d.logger.Errorw("Failed to create UdpIO", "error", err)
+			return fmt.Errorf("create new UdpIO: %w", err)
+		}
+
+		d.sliderController = udp
+		d.logger.Info("Created UDP SliderController")
 	}
 
 	// initialize the session map
@@ -143,29 +156,37 @@ func (d *Deej) run() {
 
 	// connect to the arduino for the first time
 	go func() {
-		if err := d.serial.Start(); err != nil {
-			d.logger.Warnw("Failed to start first-time serial connection", "error", err)
+		if err := d.sliderController.Start(); err != nil {
+			d.logger.Warnw("Failed to start first-time slider connection", "error", err)
 
-			// If the port is busy, that's because something else is connected - notify and quit
-			if errors.Is(err, os.ErrPermission) {
-				d.logger.Warnw("Serial port seems busy, notifying user and closing",
-					"comPort", d.config.ConnectionInfo.COMPort)
+			if d.config.ControllerType == "serial" {
+				// If the port is busy, that's because something else is connected - notify and quit
+				if errors.Is(err, os.ErrPermission) {
+					d.logger.Warnw("Serial port seems busy, notifying user and closing",
+						"comPort", d.config.SerialConnectionInfo.COMPort)
 
-				d.notifier.Notify(fmt.Sprintf("Can't connect to %s!", d.config.ConnectionInfo.COMPort),
-					"This serial port is busy, make sure to close any serial monitor or other deej instance.")
+					d.notifier.Notify(fmt.Sprintf("Can't connect to %s!", d.config.SerialConnectionInfo.COMPort),
+						"This slider port is busy, make sure to close any slider monitor or other deej instance.")
 
-				d.signalStop()
+					d.signalStop()
 
-				// also notify if the COM port they gave isn't found, maybe their config is wrong
-			} else if errors.Is(err, os.ErrNotExist) {
-				d.logger.Warnw("Provided COM port seems wrong, notifying user and closing",
-					"comPort", d.config.ConnectionInfo.COMPort)
+					// also notify if the COM port they gave isn't found, maybe their config is wrong
+				} else if errors.Is(err, os.ErrNotExist) {
+					d.logger.Warnw("Provided COM port seems wrong, notifying user and closing",
+						"comPort", d.config.SerialConnectionInfo.COMPort)
 
-				d.notifier.Notify(fmt.Sprintf("Can't connect to %s!", d.config.ConnectionInfo.COMPort),
-					"This serial port doesn't exist, check your configuration and make sure it's set correctly.")
+					d.notifier.Notify(fmt.Sprintf("Can't connect to %s!", d.config.SerialConnectionInfo.COMPort),
+						"This slider port doesn't exist, check your configuration and make sure it's set correctly.")
+
+					d.signalStop()
+				}
+			} else if d.config.ControllerType == "udp" {
+				d.notifier.Notify(fmt.Sprintf("Could not start UDP listener on port %d!", d.config.UdpConnectionInfo.UdpPort),
+					"This UDP port is busy, make sure to close any slider monitor or other deej instance.")
 
 				d.signalStop()
 			}
+
 		}
 	}()
 
@@ -191,7 +212,7 @@ func (d *Deej) stop() error {
 	d.logger.Info("Stopping")
 
 	d.config.StopWatchingConfigFile()
-	d.serial.Stop()
+	d.sliderController.Stop()
 
 	// release the session map
 	if err := d.sessions.release(); err != nil {

--- a/pkg/deej/session_map.go
+++ b/pkg/deej/session_map.go
@@ -137,7 +137,7 @@ func (m *sessionMap) setupOnConfigReload() {
 }
 
 func (m *sessionMap) setupOnSliderMove() {
-	sliderEventsChannel := m.deej.serial.SubscribeToSliderMoveEvents()
+	sliderEventsChannel := m.deej.sliderController.SubscribeToSliderMoveEvents()
 
 	go func() {
 		for {

--- a/pkg/deej/slider_controller.go
+++ b/pkg/deej/slider_controller.go
@@ -1,0 +1,13 @@
+package deej
+
+type SliderController interface {
+	Start() error
+	Stop()
+	SubscribeToSliderMoveEvents() chan SliderMoveEvent
+}
+
+// SliderMoveEvent represents a single slider move captured by deej
+type SliderMoveEvent struct {
+	SliderID     int
+	PercentValue float32
+}

--- a/pkg/deej/udp.go
+++ b/pkg/deej/udp.go
@@ -1,0 +1,248 @@
+package deej
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/omriharel/deej/pkg/deej/util"
+)
+
+// UdpIO provides a deej-aware abstraction layer to managing UDP connections
+type UdpIO struct {
+	port uint
+
+	deej   *Deej
+	logger *zap.SugaredLogger
+
+	stopChannel chan bool
+
+	lastKnownNumSliders        int
+	currentSliderPercentValues []float32
+
+	connection *net.UDPConn
+
+	sliderMoveConsumers []chan SliderMoveEvent
+}
+
+var expectedUdpLinePattern = regexp.MustCompile(`^\d{1,4}(\|\d{1,4})*$`)
+
+// NewUdpIO creates a UdpIO instance that uses the provided deej
+// instance's connection info to establish communications with the controller
+func NewUdpIO(deej *Deej, logger *zap.SugaredLogger) (*UdpIO, error) {
+	logger = logger.Named("udp")
+
+	udpio := &UdpIO{
+		deej:                deej,
+		logger:              logger,
+		stopChannel:         make(chan bool),
+		sliderMoveConsumers: []chan SliderMoveEvent{},
+	}
+
+	logger.Debug("Created UDP i/o instance")
+
+	// respond to config changes
+	udpio.setupOnConfigReload()
+
+	return udpio, nil
+}
+
+// Start creates a UDP listener server
+func (udpio *UdpIO) Start() error {
+	s, err := net.ResolveUDPAddr("udp4", fmt.Sprintf(":%d", udpio.deej.config.UdpConnectionInfo.UdpPort))
+	if err != nil {
+		udpio.logger.Warnw("Failed to resolve UDP address", "error", err)
+		return fmt.Errorf("resolve udp address: %w", err)
+	}
+
+	connection, err := net.ListenUDP("udp4", s)
+	if err != nil {
+		udpio.logger.Warnw("Failed to start UDP listener", "error", err)
+		return fmt.Errorf("start udp listener: %w", err)
+	}
+
+	udpio.connection = connection
+
+	namedLogger := udpio.logger.Named(fmt.Sprintf(":%d", udpio.deej.config.UdpConnectionInfo.UdpPort))
+
+	namedLogger.Infow("Connected", "conn", udpio.connection)
+
+	// read lines or await a stop
+	go func() {
+		packetChannel := udpio.readPacket(namedLogger)
+
+		for {
+			select {
+			case <-udpio.stopChannel:
+				udpio.close(namedLogger)
+			case packet := <-packetChannel:
+				udpio.handlePacket(namedLogger, packet)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (udpio *UdpIO) readPacket(logger *zap.SugaredLogger) chan string {
+	packetChannel := make(chan string)
+
+	go func() {
+		for {
+			packet := make([]byte, 4096)
+			bytesRead, _, err := udpio.connection.ReadFromUDP(packet)
+
+			if err != nil {
+
+				if udpio.deej.Verbose() {
+					logger.Warnw("Failed to read UDP packet", "error", err)
+				}
+
+				return
+			}
+
+			stringData := string(packet[:bytesRead])
+
+			if udpio.deej.Verbose() {
+				logger.Debugw("Read new packet", "packet", stringData)
+			}
+
+			packetChannel <- stringData
+		}
+	}()
+
+	return packetChannel
+}
+
+func (udpio *UdpIO) close(logger *zap.SugaredLogger) {
+	if err := udpio.connection.Close(); err != nil {
+		logger.Warnw("Failed to close UDP connection", "error", err)
+	} else {
+		logger.Debug("UDP connection closed")
+	}
+
+	udpio.connection = nil
+}
+
+// Stop signals us to shut down our slider connection, if one is active
+func (udpio *UdpIO) Stop() {
+	if udpio.connection != nil {
+		udpio.logger.Debug("Shutting down serial connection")
+		udpio.stopChannel <- true
+	} else {
+		udpio.logger.Debug("Not currently connected, nothing to stop")
+	}
+}
+
+// SubscribeToSliderMoveEvents returns an unbuffered channel that receives
+// a sliderMoveEvent struct every time a slider moves
+func (udpio *UdpIO) SubscribeToSliderMoveEvents() chan SliderMoveEvent {
+	ch := make(chan SliderMoveEvent)
+	udpio.sliderMoveConsumers = append(udpio.sliderMoveConsumers, ch)
+
+	return ch
+}
+
+func (udpio *UdpIO) setupOnConfigReload() {
+	configReloadedChannel := udpio.deej.config.SubscribeToChanges()
+
+	const stopDelay = 50 * time.Millisecond
+
+	go func() {
+		for {
+			select {
+			case <-configReloadedChannel:
+
+				// make any config reload unset our slider number to ensure process volumes are being re-set
+				// (the next read line will emit SliderMoveEvent instances for all sliders)\
+				// this needs to happen after a small delay, because the session map will also re-acquire sessions
+				// whenever the config file is reloaded, and we don't want it to receive these move events while the map
+				// is still cleared. this is kind of ugly, but shouldn't cause any issues
+				go func() {
+					<-time.After(stopDelay)
+					udpio.lastKnownNumSliders = 0
+				}()
+
+				// if connection params have changed, attempt to stop and start the connection
+			}
+		}
+	}()
+}
+
+func (udpio *UdpIO) handlePacket(logger *zap.SugaredLogger, packet string) {
+	if !expectedUdpLinePattern.MatchString(packet) {
+		return
+	}
+
+	// split on pipe (|), this gives a slice of numerical strings between "0" and "1023"
+	splitLine := strings.Split(packet, "|")
+	numSliders := len(splitLine)
+
+	// update our slider count, if needed - this will send slider move events for all
+	if numSliders != udpio.lastKnownNumSliders {
+		logger.Infow("Detected sliders", "amount", numSliders)
+		udpio.lastKnownNumSliders = numSliders
+		udpio.currentSliderPercentValues = make([]float32, numSliders)
+
+		// reset everything to be an impossible value to force the slider move event later
+		for idx := range udpio.currentSliderPercentValues {
+			udpio.currentSliderPercentValues[idx] = -1.0
+		}
+	}
+
+	// for each slider:
+	moveEvents := []SliderMoveEvent{}
+	for sliderIdx, stringValue := range splitLine {
+
+		// convert string values to integers ("1023" -> 1023)
+		number, _ := strconv.Atoi(string(stringValue))
+
+		// turns out the first line could come out dirty sometimes (i.e. "4558|925|41|643|220")
+		// so let's check the first number for correctness just in case
+		if sliderIdx == 0 && number > 1023 {
+			udpio.logger.Debugw("Got malformed packet from UDP, ignoring", "packet", packet)
+			return
+		}
+
+		// map the value from raw to a "dirty" float between 0 and 1 (e.g. 0.15451...)
+		dirtyFloat := float32(number) / 1023.0
+
+		// normalize it to an actual volume scalar between 0.0 and 1.0 with 2 points of precision
+		normalizedScalar := util.NormalizeScalar(dirtyFloat)
+
+		// if sliders are inverted, take the complement of 1.0
+		if udpio.deej.config.InvertSliders {
+			normalizedScalar = 1 - normalizedScalar
+		}
+
+		// check if it changes the desired state (could just be a jumpy raw slider value)
+		if util.SignificantlyDifferent(udpio.currentSliderPercentValues[sliderIdx], normalizedScalar, udpio.deej.config.NoiseReductionLevel) {
+
+			// if it does, update the saved value and create a move event
+			udpio.currentSliderPercentValues[sliderIdx] = normalizedScalar
+
+			moveEvents = append(moveEvents, SliderMoveEvent{
+				SliderID:     sliderIdx,
+				PercentValue: normalizedScalar,
+			})
+
+			if udpio.deej.Verbose() {
+				logger.Debugw("Slider moved", "event", moveEvents[len(moveEvents)-1])
+			}
+		}
+	}
+
+	// deliver move events if there are any, towards all potential consumers
+	if len(moveEvents) > 0 {
+		for _, consumer := range udpio.sliderMoveConsumers {
+			for _, moveEvent := range moveEvents {
+				consumer <- moveEvent
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a UDP backend that allows users to control deej via the network. It uses the same protocol format as the serial message (minus the `\r\n` at the end of each message) and can be selected through the configuration file. All configuration options still default to serial unless the user specifically chose the UDP backend.

My specific use case is to be able to control two separate computers with a single microcontroller. I'm using an ESP32, and I'm sending data for the first few faders to one laptop, and data for the remaining faders to the other laptop.

This effectively enables anything with a working network connection to control deej, which is really cool. On the other hand, since there is no authentication, this enables _anything_ with a network connection to control deej. :stuck_out_tongue_winking_eye: I think it's an acceptable compromise since the user would have to explicitly select the UDP backend, and I think we can "market" it towards more tech-savy users anyway.

I did not include a basic sketch for this because it requires a bit more setup than just a single `.ino` file, and I only mentioned this new backend in passing in the README. I'm thinking we could maybe have a Wiki page specifically on this topic?

Let me know your thoughts!