### PR TITLE
Button support 

### DIFF
--- a/arduino/deej-5-sliders-vanilla/deej-5-sliders-vanilla.ino
+++ b/arduino/deej-5-sliders-vanilla/deej-5-sliders-vanilla.ino
@@ -1,11 +1,18 @@
 const int NUM_SLIDERS = 5;
 const int analogInputs[NUM_SLIDERS] = {A0, A1, A2, A3, A4};
+const int NUM_BUTTONS = 1;
+const int buttonInputs[NUM_BUTTONS] = {9};
 
 int analogSliderValues[NUM_SLIDERS];
+int buttonValues[NUM_BUTTONS];
 
-void setup() { 
+void setup() {
   for (int i = 0; i < NUM_SLIDERS; i++) {
     pinMode(analogInputs[i], INPUT);
+  }
+
+  for (int i = 0; i < NUM_BUTTONS; i++) {
+    pinMode(buttonInputs[i], INPUT);
   }
 
   Serial.begin(9600);
@@ -14,13 +21,16 @@ void setup() {
 void loop() {
   updateSliderValues();
   sendSliderValues(); // Actually send data (all the time)
-  // printSliderValues(); // For debug
+//   printSliderValues(); // For debug
   delay(10);
 }
 
 void updateSliderValues() {
   for (int i = 0; i < NUM_SLIDERS; i++) {
-     analogSliderValues[i] = analogRead(analogInputs[i]);
+    analogSliderValues[i] = analogRead(analogInputs[i]);
+  }
+  for (int i = 0; i < NUM_BUTTONS; i++) {
+    buttonValues[i] = digitalRead(buttonInputs[i]);
   }
 }
 
@@ -28,13 +38,27 @@ void sendSliderValues() {
   String builtString = String("");
 
   for (int i = 0; i < NUM_SLIDERS; i++) {
+    builtString += "s";
     builtString += String((int)analogSliderValues[i]);
 
     if (i < NUM_SLIDERS - 1) {
       builtString += String("|");
     }
   }
-  
+
+  if(NUM_BUTTONS > 0){
+    builtString += String("|");
+  }
+
+  for (int i = 0; i < NUM_BUTTONS; i++) {
+    builtString += "b";
+    builtString += String((int)buttonValues[i]);
+
+    if (i < NUM_BUTTONS - 1) {
+      builtString += String("|");
+    }
+  }
+
   Serial.println(builtString);
 }
 

--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,9 @@ slider_mapping:
     - rocketleague.exe
   4: discord.exe
 
+button_mapping:
+  0: VK_VOLUME_MUTE
+
 # set this to true if you want the controls inverted (i.e. top is 0%, bottom is 100%)
 invert_sliders: false
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/jfreymuth/pulse v0.0.0-20200608153616-84b2d752b9d4
 	github.com/lxn/walk v0.0.0-20191128110447-55ccb3a9f5c1 // indirect
 	github.com/lxn/win v0.0.0-20191128105842-2da648fda5b4
+	github.com/micmonay/keybd_event v1.1.1 // indirect
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/moutend/go-wca v0.1.2-0.20190422112502-0fa027b3d89a
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/micmonay/keybd_event v1.1.1 h1:rv7omwXWYL9Lgf3PUq6uBgJI2k1yGkL/GD6dxc6nmSs=
+github.com/micmonay/keybd_event v1.1.1/go.mod h1:CGMWMDNgsfPljzrAWoybUOSKafQPZpv+rLigt2LzNGI=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/pkg/deej/serial.go
+++ b/pkg/deej/serial.go
@@ -31,8 +31,11 @@ type SerialIO struct {
 
 	lastKnownNumSliders        int
 	currentSliderPercentValues []float32
+	lastKnownNumButtons        int
+	currentButtonValues 			 []int
 
 	sliderMoveConsumers []chan SliderMoveEvent
+	buttonEventConsumers []chan ButtonEvent
 }
 
 // SliderMoveEvent represents a single slider move captured by deej
@@ -41,7 +44,13 @@ type SliderMoveEvent struct {
 	PercentValue float32
 }
 
-var expectedLinePattern = regexp.MustCompile(`^\d{1,4}(\|\d{1,4})*\r\n$`)
+// SliderMoveEvent represents a single slider move captured by deej
+type ButtonEvent struct {
+	ButtonID     int
+	Value 			 int
+}
+
+var expectedLinePattern = regexp.MustCompile(`^\w{1}\d{1,4}(\|\w{1}\d{1,4})*\r\n$`)
 
 // NewSerialIO creates a SerialIO instance that uses the provided deej
 // instance's connection info to establish communications with the arduino chip
@@ -55,6 +64,7 @@ func NewSerialIO(deej *Deej, logger *zap.SugaredLogger) (*SerialIO, error) {
 		connected:           false,
 		conn:                nil,
 		sliderMoveConsumers: []chan SliderMoveEvent{},
+		buttonEventConsumers: []chan ButtonEvent{},
 	}
 
 	logger.Debug("Created serial i/o instance")
@@ -142,6 +152,13 @@ func (sio *SerialIO) Stop() {
 func (sio *SerialIO) SubscribeToSliderMoveEvents() chan SliderMoveEvent {
 	ch := make(chan SliderMoveEvent)
 	sio.sliderMoveConsumers = append(sio.sliderMoveConsumers, ch)
+
+	return ch
+}
+
+func (sio *SerialIO) SubscribeToButtonEvents() chan ButtonEvent {
+	ch := make(chan ButtonEvent)
+	sio.buttonEventConsumers = append(sio.buttonEventConsumers, ch)
 
 	return ch
 }
@@ -240,7 +257,20 @@ func (sio *SerialIO) handleLine(logger *zap.SugaredLogger, line string) {
 
 	// split on pipe (|), this gives a slice of numerical strings between "0" and "1023"
 	splitLine := strings.Split(line, "|")
-	numSliders := len(splitLine)
+
+	splitLineSliders := []string{}
+	splitLineButtons := []string{}
+
+	for _, splitValue := range splitLine {
+		if splitValue[0] == 's' {
+			splitLineSliders = append(splitLineSliders, strings.Replace(splitValue, "s", "", -1))
+		}else if splitValue[0] == 'b' {
+			splitLineButtons = append(splitLineButtons, strings.Replace(splitValue, "b", "", -1))
+		}
+	}
+
+	numSliders := len(splitLineSliders)
+	numButtons := len(splitLineButtons)
 
 	// update our slider count, if needed - this will send slider move events for all
 	if numSliders != sio.lastKnownNumSliders {
@@ -254,46 +284,88 @@ func (sio *SerialIO) handleLine(logger *zap.SugaredLogger, line string) {
 		}
 	}
 
+	if numButtons != sio.lastKnownNumButtons {
+		logger.Infow("Detected buttons", "amount", numButtons)
+		sio.lastKnownNumButtons = numButtons
+		sio.currentButtonValues = make([]int, numButtons)
+
+		// reset everything to be an impossible value to force the slider move event later
+		for idx := range sio.currentButtonValues {
+			sio.currentButtonValues[idx] = -1.0
+		}
+	}
+
 	// for each slider:
 	moveEvents := []SliderMoveEvent{}
-	for sliderIdx, stringValue := range splitLine {
+	for sliderIdx, stringValue := range splitLineSliders {
 
-		// convert string values to integers ("1023" -> 1023)
-		number, _ := strconv.Atoi(stringValue)
+		// logger.Debug(stringValue);
 
-		// turns out the first line could come out dirty sometimes (i.e. "4558|925|41|643|220")
-		// so let's check the first number for correctness just in case
-		if sliderIdx == 0 && number > 1023 {
-			sio.logger.Debugw("Got malformed line from serial, ignoring", "line", line)
-			return
-		}
 
-		// map the value from raw to a "dirty" float between 0 and 1 (e.g. 0.15451...)
-		dirtyFloat := float32(number) / 1023.0
+			// convert string values to integers ("1023" -> 1023)
+			number, _ := strconv.Atoi(stringValue)
 
-		// normalize it to an actual volume scalar between 0.0 and 1.0 with 2 points of precision
-		normalizedScalar := util.NormalizeScalar(dirtyFloat)
-
-		// if sliders are inverted, take the complement of 1.0
-		if sio.deej.config.InvertSliders {
-			normalizedScalar = 1 - normalizedScalar
-		}
-
-		// check if it changes the desired state (could just be a jumpy raw slider value)
-		if util.SignificantlyDifferent(sio.currentSliderPercentValues[sliderIdx], normalizedScalar, sio.deej.config.NoiseReductionLevel) {
-
-			// if it does, update the saved value and create a move event
-			sio.currentSliderPercentValues[sliderIdx] = normalizedScalar
-
-			moveEvents = append(moveEvents, SliderMoveEvent{
-				SliderID:     sliderIdx,
-				PercentValue: normalizedScalar,
-			})
-
-			if sio.deej.Verbose() {
-				logger.Debugw("Slider moved", "event", moveEvents[len(moveEvents)-1])
+			// turns out the first line could come out dirty sometimes (i.e. "4558|925|41|643|220")
+			// so let's check the first number for correctness just in case
+			if sliderIdx == 0 && number > 1023 {
+				sio.logger.Debugw("Got malformed line from serial, ignoring", "line", line)
+				return
 			}
-		}
+
+			// map the value from raw to a "dirty" float between 0 and 1 (e.g. 0.15451...)
+			dirtyFloat := float32(number) / 1023.0
+
+			// normalize it to an actual volume scalar between 0.0 and 1.0 with 2 points of precision
+			normalizedScalar := util.NormalizeScalar(dirtyFloat)
+
+			// if sliders are inverted, take the complement of 1.0
+			if sio.deej.config.InvertSliders {
+				normalizedScalar = 1 - normalizedScalar
+			}
+
+			// check if it changes the desired state (could just be a jumpy raw slider value)
+			if util.SignificantlyDifferent(sio.currentSliderPercentValues[sliderIdx], normalizedScalar, sio.deej.config.NoiseReductionLevel) {
+
+				// if it does, update the saved value and create a move event
+				sio.currentSliderPercentValues[sliderIdx] = normalizedScalar
+
+				moveEvents = append(moveEvents, SliderMoveEvent{
+					SliderID:     sliderIdx,
+					PercentValue: normalizedScalar,
+				})
+
+				if sio.deej.Verbose() {
+					logger.Debugw("Slider moved", "event", moveEvents[len(moveEvents)-1])
+				}
+			}
+
+
+	}
+
+	buttonEvents := []ButtonEvent{}
+	for buttonId, stringValue := range splitLineButtons {
+
+		
+			//button handler
+			stringValue = strings.Replace(stringValue, "b", "", -1)
+			number, _ := strconv.Atoi(stringValue)
+			
+			if sio.currentButtonValues[buttonId] != number {
+
+				sio.currentButtonValues[buttonId] = number
+
+				buttonEvents = append(buttonEvents, ButtonEvent{
+					ButtonID:     buttonId,
+					Value: 				number,
+				})
+
+				// if sio.deej.Verbose() {
+					logger.Debugw("Button changed", "event", buttonEvents[len(buttonEvents)-1])
+				// }
+
+			}
+
+
 	}
 
 	// deliver move events if there are any, towards all potential consumers
@@ -301,6 +373,14 @@ func (sio *SerialIO) handleLine(logger *zap.SugaredLogger, line string) {
 		for _, consumer := range sio.sliderMoveConsumers {
 			for _, moveEvent := range moveEvents {
 				consumer <- moveEvent
+			}
+		}
+	}
+
+	if len(buttonEvents) > 0 {
+		for _, consumer := range sio.buttonEventConsumers {
+			for _, buttonEvent := range buttonEvents {
+				consumer <- buttonEvent
 			}
 		}
 	}


### PR DESCRIPTION
Added button support. This was done by modifying the serial output of the Arduino and updating the parsing code in the app to handle the new format.  The new serial now looks like this:
```
s495|s169|s1022|b0
```
where `s` means slider value and `b` means button value.

For keyboard emulation, I'm using https://github.com/micmonay/keybd_event. It provides pretty much every keyboard key imaginable and supports modifiers.

Todo:

- [ ] Add config support
- - [ ] Support single keycodes
- - [ ] Support modifiers
- [ ] Support both Windows and Linux (I won't be able to test the Linux implementation so might need someone to help me)

Extra stuff:

- [ ] Currently, the key event is only sent when the button is pressed. Maybe add an option to send it again when releasing the key? Maybe different key codes when going from `off > on` and `on > off`?