### PR TITLE
Debounce serial comms to hopefully prevent PC wake-up

### DIFF
--- a/arduino/deej-5-sliders-vanilla/deej-5-sliders-vanilla.ino
+++ b/arduino/deej-5-sliders-vanilla/deej-5-sliders-vanilla.ino
@@ -1,7 +1,9 @@
 const int NUM_SLIDERS = 5;
+const int MIN_DELTA = 2;
 const int analogInputs[NUM_SLIDERS] = {A0, A1, A2, A3, A4};
 
 int analogSliderValues[NUM_SLIDERS];
+bool doUpdate = false;
 
 void setup() { 
   for (int i = 0; i < NUM_SLIDERS; i++) {
@@ -13,14 +15,29 @@ void setup() {
 
 void loop() {
   updateSliderValues();
-  sendSliderValues(); // Actually send data (all the time)
+  if(doUpdate)
+  {
+    sendSliderValues();
+    doUpdate = false;
+  }
+
   // printSliderValues(); // For debug
   delay(10);
 }
 
 void updateSliderValues() {
-  for (int i = 0; i < NUM_SLIDERS; i++) {
-     analogSliderValues[i] = analogRead(analogInputs[i]);
+  int newVal = 0;
+
+  for (int i = 0; i < NUM_SLIDERS; i++)
+  {
+    newVal = analogRead(analogInputs[i]);
+
+    // Debounce serial comms
+    if(abs(newVal - analogSliderValues[i]) >= MIN_DELTA)
+    {
+      analogSliderValues[i] = newVal;
+      doUpdate = true;
+    }
   }
 }
 


### PR DESCRIPTION
First pass on create a simple debounce with a threshold to prevent the serial port constantly spamming when no changes are made. My PC is waking up every night from one of the USB devices and wanted to throttle the comms at the hardware level.

Currently have this modification installed on my nano; will report back if everything continues to work fine for some days.