### PR TITLE
Fix Windows make scripts

### DIFF
--- a/pkg/deej/scripts/windows/make-icon.bat
+++ b/pkg/deej/scripts/windows/make-icon.bat
@@ -15,12 +15,12 @@ GOTO DONE
 
 :INSTALL
 ECHO Installing 2goarray...
-go get github.com/cratonica/2goarray
+go install github.com/cratonica/2goarray
 IF ERRORLEVEL 1 GOTO GETFAIL
 GOTO POSTINSTALL
 
 :GETFAIL
-ECHO Failure running go get github.com/cratonica/2goarray.  Ensure that go and git are in PATH
+ECHO Failure running go install github.com/cratonica/2goarray.  Ensure that go and git are in PATH
 GOTO DONE
 
 :NOGO

--- a/pkg/deej/scripts/windows/make-rsrc.bat
+++ b/pkg/deej/scripts/windows/make-rsrc.bat
@@ -9,12 +9,12 @@ GOTO DONE
 
 :INSTALL
 ECHO Installing rsrc...
-go get  github.com/akavel/rsrc
+go install  github.com/akavel/rsrc
 IF ERRORLEVEL 1 GOTO GETFAIL
 GOTO POSTINSTALL
 
 :GETFAIL
-ECHO Failure running go get  github.com/akavel/rsrc.  Ensure that go and git are in PATH
+ECHO Failure running go install  github.com/akavel/rsrc.  Ensure that go and git are in PATH
 GOTO DONE
 
 :NOGO


### PR DESCRIPTION
`go get` no longer install the required dependencies in the included Windows make scripts.

Replaced all `go get` references with `go install`.