### PR TITLE
add max_slider_value to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,11 @@ slider_mapping:
 # set this to true if you want the controls inverted (i.e. top is 0%, bottom is 100%)
 invert_sliders: false
 
+# Set the max slider value in case your potentiometers do not reach the default value of 1023. 
+# This is for people that made the mistake of logarithmic potentiometers that only reach a value of 800-900. 
+# Find your max_slider_value by using a serial monitor in the arduino software or viewing debug terminal. 
+max_slider_value: 1023
+
 # settings for connecting to the arduino board
 com_port: COM4
 baud_rate: 9600

--- a/pkg/deej/config.go
+++ b/pkg/deej/config.go
@@ -19,8 +19,9 @@ type CanonicalConfig struct {
 	SliderMapping *sliderMap
 
 	ConnectionInfo struct {
-		COMPort  string
-		BaudRate int
+		COMPort          string
+		BaudRate         int
+		max_slider_value int
 	}
 
 	InvertSliders bool
@@ -53,9 +54,11 @@ const (
 	configKeyCOMPort             = "com_port"
 	configKeyBaudRate            = "baud_rate"
 	configKeyNoiseReductionLevel = "noise_reduction"
+	configMaxSliderValue         = "max_slider_value"
 
-	defaultCOMPort  = "COM4"
-	defaultBaudRate = 9600
+	defaultMaxSliderValue = "1023"
+	defaultCOMPort        = "COM4"
+	defaultBaudRate       = 9600
 )
 
 // has to be defined as a non-constant because we're using path.Join
@@ -89,6 +92,7 @@ func NewConfig(logger *zap.SugaredLogger, notifier Notifier) (*CanonicalConfig, 
 	userConfig.SetDefault(configKeyInvertSliders, false)
 	userConfig.SetDefault(configKeyCOMPort, defaultCOMPort)
 	userConfig.SetDefault(configKeyBaudRate, defaultBaudRate)
+	userConfig.SetDefault(configMaxSliderValue, defaultMaxSliderValue)
 
 	internalConfig := viper.New()
 	internalConfig.SetConfigName(internalConfigName)
@@ -225,6 +229,7 @@ func (cc *CanonicalConfig) populateFromVipers() error {
 
 	// get the rest of the config fields - viper saves us a lot of effort here
 	cc.ConnectionInfo.COMPort = cc.userConfig.GetString(configKeyCOMPort)
+	cc.ConnectionInfo.max_slider_value = cc.userConfig.GetInt(configMaxSliderValue)
 
 	cc.ConnectionInfo.BaudRate = cc.userConfig.GetInt(configKeyBaudRate)
 	if cc.ConnectionInfo.BaudRate <= 0 {

--- a/pkg/deej/serial.go
+++ b/pkg/deej/serial.go
@@ -31,6 +31,7 @@ type SerialIO struct {
 
 	lastKnownNumSliders        int
 	currentSliderPercentValues []float32
+	maxSliderInput             int
 
 	sliderMoveConsumers []chan SliderMoveEvent
 }
@@ -263,13 +264,15 @@ func (sio *SerialIO) handleLine(logger *zap.SugaredLogger, line string) {
 
 		// turns out the first line could come out dirty sometimes (i.e. "4558|925|41|643|220")
 		// so let's check the first number for correctness just in case
-		if sliderIdx == 0 && number > 1023 {
+		//if sliderIdx == 0 && number > 1023 {
+		if sliderIdx == 0 && number > sio.deej.config.ConnectionInfo.max_slider_value+2 {
 			sio.logger.Debugw("Got malformed line from serial, ignoring", "line", line)
 			return
 		}
 
 		// map the value from raw to a "dirty" float between 0 and 1 (e.g. 0.15451...)
-		dirtyFloat := float32(number) / 1023.0
+		//dirtyFloat := float32(number) / 1023.0
+		dirtyFloat := float32(number) / float32(sio.deej.config.ConnectionInfo.max_slider_value)
 
 		// normalize it to an actual volume scalar between 0.0 and 1.0 with 2 points of precision
 		normalizedScalar := util.NormalizeScalar(dirtyFloat)


### PR DESCRIPTION
# Notes
For sliders that cannot reach the full analog range, use max_slider_value in the config.yaml to adjust the range from 0 to max_slider_value.

I wrote this because I made the mistake of using Logarithmic Potentiometers, which only reach a value of 900.

Converting a logarithmic value to linear, wasn't ideal for range / sensitivity.

So adjusting the max value in range, works very well to remedy this issue.