### PR TITLE
Add max_analog_read to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,7 @@ invert_sliders: false
 # settings for connecting to the arduino board
 com_port: COM4
 baud_rate: 9600
+analog_read_max: 1023
 
 # adjust the amount of signal noise reduction depending on your hardware quality
 # supported values are "low" (excellent hardware), "default" (regular hardware) or "high" (bad, noisy hardware)

--- a/pkg/deej/config.go
+++ b/pkg/deej/config.go
@@ -19,8 +19,9 @@ type CanonicalConfig struct {
 	SliderMapping *sliderMap
 
 	ConnectionInfo struct {
-		COMPort  string
-		BaudRate int
+		COMPort       string
+		BaudRate      int
+		AnalogReadMax int
 	}
 
 	InvertSliders bool
@@ -52,10 +53,12 @@ const (
 	configKeyInvertSliders       = "invert_sliders"
 	configKeyCOMPort             = "com_port"
 	configKeyBaudRate            = "baud_rate"
+	configKeyAnalogReadMax       = "analog_read_max"
 	configKeyNoiseReductionLevel = "noise_reduction"
 
-	defaultCOMPort  = "COM4"
-	defaultBaudRate = 9600
+	defaultCOMPort       = "COM4"
+	defaultBaudRate      = 9600
+	defaultAnalogReadMax = 1023
 )
 
 // has to be defined as a non-constant because we're using path.Join
@@ -89,6 +92,7 @@ func NewConfig(logger *zap.SugaredLogger, notifier Notifier) (*CanonicalConfig, 
 	userConfig.SetDefault(configKeyInvertSliders, false)
 	userConfig.SetDefault(configKeyCOMPort, defaultCOMPort)
 	userConfig.SetDefault(configKeyBaudRate, defaultBaudRate)
+	userConfig.SetDefault(configKeyAnalogReadMax, defaultAnalogReadMax)
 
 	internalConfig := viper.New()
 	internalConfig.SetConfigName(internalConfigName)
@@ -225,7 +229,7 @@ func (cc *CanonicalConfig) populateFromVipers() error {
 
 	// get the rest of the config fields - viper saves us a lot of effort here
 	cc.ConnectionInfo.COMPort = cc.userConfig.GetString(configKeyCOMPort)
-
+	cc.ConnectionInfo.AnalogReadMax = cc.userConfig.GetInt(configKeyAnalogReadMax)
 	cc.ConnectionInfo.BaudRate = cc.userConfig.GetInt(configKeyBaudRate)
 	if cc.ConnectionInfo.BaudRate <= 0 {
 		cc.logger.Warnw("Invalid baud rate specified, using default value",

--- a/pkg/deej/serial.go
+++ b/pkg/deej/serial.go
@@ -238,7 +238,7 @@ func (sio *SerialIO) handleLine(logger *zap.SugaredLogger, line string) {
 	// trim the suffix
 	line = strings.TrimSuffix(line, "\r\n")
 
-	// split on pipe (|), this gives a slice of numerical strings between "0" and "1023"
+	// split on pipe (|), this gives a slice of numerical strings between "0" and max_analog_read (default "1023")
 	splitLine := strings.Split(line, "|")
 	numSliders := len(splitLine)
 
@@ -263,13 +263,13 @@ func (sio *SerialIO) handleLine(logger *zap.SugaredLogger, line string) {
 
 		// turns out the first line could come out dirty sometimes (i.e. "4558|925|41|643|220")
 		// so let's check the first number for correctness just in case
-		if sliderIdx == 0 && number > 1023 {
+		if sliderIdx == 0 && number > sio.deej.config.ConnectionInfo.AnalogReadMax {
 			sio.logger.Debugw("Got malformed line from serial, ignoring", "line", line)
 			return
 		}
 
 		// map the value from raw to a "dirty" float between 0 and 1 (e.g. 0.15451...)
-		dirtyFloat := float32(number) / 1023.0
+		dirtyFloat := float32(number) / float32(sio.deej.config.ConnectionInfo.AnalogReadMax)
 
 		// normalize it to an actual volume scalar between 0.0 and 1.0 with 2 points of precision
 		normalizedScalar := util.NormalizeScalar(dirtyFloat)


### PR DESCRIPTION
This new value allows you to define what the maximum value is that the analog read returns. By default it is set to 1023 but for example in case of a ESP32-WROOM it is 4095.
