### PR TITLE
Use up-to-date version from systray

### DIFF
--- a/pkg/deej/tray.go
+++ b/pkg/deej/tray.go
@@ -1,7 +1,7 @@
 package deej
 
 import (
-	"github.com/getlantern/systray"
+	"fyne.io/systray"
 
 	"github.com/omriharel/deej/pkg/deej/icon"
 	"github.com/omriharel/deej/pkg/deej/util"


### PR DESCRIPTION
- Change to recent version from systray to support compiling on recent Linux distributions