### PR TITLE
Send slider values only on change

### DIFF
--- a/arduino/deej-5-sliders-vanilla/deej-5-sliders-vanilla.ino
+++ b/arduino/deej-5-sliders-vanilla/deej-5-sliders-vanilla.ino
@@ -1,11 +1,23 @@
 const int NUM_SLIDERS = 5;
 const int analogInputs[NUM_SLIDERS] = {A0, A1, A2, A3, A4};
 
+// minimum slider change before sending new value
+// 2 is good for good pots that just sometimes waver between two values
+// 1 will send every change
+// 0 effectively turns off the "send on change" and sends the state every loop
+const int MIN_CHANGE = 2; 
+
+int lastSliderValues[NUM_SLIDERS];
 int analogSliderValues[NUM_SLIDERS];
 
 void setup() { 
   for (int i = 0; i < NUM_SLIDERS; i++) {
     pinMode(analogInputs[i], INPUT);
+  }
+
+  // init with impossible values so the first loop always sends current state
+  for (int i = 0; i < NUM_SLIDERS; i++) {
+     lastSliderValues[i] = -1;
   }
 
   Serial.begin(9600);
@@ -25,6 +37,12 @@ void updateSliderValues() {
 }
 
 void sendSliderValues() {
+  if (!isChange()) {
+    return;
+  }
+
+  updateLastValues();
+
   String builtString = String("");
 
   for (int i = 0; i < NUM_SLIDERS; i++) {
@@ -48,5 +66,23 @@ void printSliderValues() {
     } else {
       Serial.write("\n");
     }
+  }
+}
+
+// true if at least one slider has changed by at least MIN_CHANGE
+// false otherwise
+bool isChange() {
+  for (int i = 0; i < NUM_SLIDERS; i++) {
+    int diff = abs(analogSliderValues[i] - lastSliderValues[i]);
+    if (diff >= MIN_CHANGE) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void updateLastValues() {
+  for (int i = 0; i < NUM_SLIDERS; i++) {
+    lastSliderValues[i] = analogSliderValues[i];
   }
 }


### PR DESCRIPTION
Prior to this patch, slider values would be sent on every loop. This is unnecessary and can make initial setup difficult (e.g. when using the serial monitor to verify outputs and correct pot behaviour).

This patch introduces a `lastSliderValues` array to track the last slider values that were sent to the PC and a `MIN_CHANGE` constant to set the minimum change required before sending the new slider values.