### PR TITLE
Fix Linux session finder to fall back to PulseAudio client properties

### DIFF
--- a/pkg/deej/session_finder_linux.go
+++ b/pkg/deej/session_finder_linux.go
@@ -132,6 +132,24 @@ func (sf *paSessionFinder) enumerateAndAddSessions(sessions *[]Session) error {
 		name, ok := info.Properties["application.process.binary"]
 
 		if !ok {
+			name, ok = info.Properties["application.name"]
+		}
+
+		// For apps that connect via the native PipeWire protocol (e.g. Spotify), neither
+		// application property is present on the sink-input itself — they live on the
+		// associated PulseAudio client object instead.
+		if !ok {
+			clientReq := proto.GetClientInfo{ClientIndex: info.ClientIndex}
+			clientReply := proto.GetClientInfoReply{}
+			if err := sf.client.Request(&clientReq, &clientReply); err == nil {
+				name, ok = clientReply.Properties["application.process.binary"]
+				if !ok {
+					name, ok = clientReply.Properties["application.name"]
+				}
+			}
+		}
+
+		if !ok {
 			sf.logger.Warnw("Failed to get sink input's process name",
 				"sinkInputIndex", info.SinkInputIndex)
 


### PR DESCRIPTION
## Description

On Linux, some apps connect to PipeWire via its **native protocol** rather than through the PulseAudio compatibility layer (`pipewire-pulse`). In this case, neither `application.process.binary` nor `application.name` is present on the sink-input's own property list — they are only available on the **associated PulseAudio client object**.

The most common example is **Spotify** (version 1.2.x+), which shows up in `pactl list sink-inputs` with only `node.name = "audio-src"` and no application identity, causing the persistent warning:

```
Failed to get sink input's process name  {"sinkInputIndex": N}
```

## Solution

This adds a two-level fallback in `enumerateAndAddSessions`:

1. Try `application.name` on the sink-input proplist (covers apps like Firefox running ALSA over PipeWire — also addressed in #161)
2. Look up the associated client via `GetClientInfo` and check both `application.process.binary` and `application.name` there (covers Spotify and other native PipeWire clients)

## Testing

Verified on CachyOS (Arch-based) with PipeWire 1.6.4, WirePlumber 0.5.14, and Spotify 1.2.86.502 (AUR). Before this fix, Spotify was silently ignored and the slider had no effect. After this fix, Spotify is correctly identified and volume control works.

## Relation to existing PRs

PR #161 adds the `application.name` sink-input fallback but does not handle the case where both properties are absent from the sink-input entirely (native PipeWire clients). This PR is a superset of that fix.